### PR TITLE
Update device update examples

### DIFF
--- a/docs/api-clients/devices/update-device.md
+++ b/docs/api-clients/devices/update-device.md
@@ -61,7 +61,9 @@ Name of Property
 {% tab title="Python" %}
 
 ```python
-seam.devices.update(device=some_device, name="My Lock")
+seam.devices.update(
+  device=some_device, 
+  name="My Lock")
 ```
 
 {% endtab %}
@@ -69,7 +71,10 @@ seam.devices.update(device=some_device, name="My Lock")
 {% tab title="Javascript" %}
 
 ```typescript
-await seam.devices.update({ device_id: "64640ab4-fa90-4818-b455-1336b78c951a", name: "My Lock" });
+await seam.devices.update({ 
+  device_id: "64640ab4-fa90-4818-b455-1336b78c951a", 
+  name: "My Lock" 
+})
 ```
 
 {% endtab %}
@@ -89,9 +94,9 @@ seam.devices.update(
 
 ```php
 $seam->devices->update(
-      device_id: "64640ab4-fa90-4818-b455-1336b78c951a",
-      name: "My Lock"
-    )
+  device_id: "64640ab4-fa90-4818-b455-1336b78c951a",
+  name: "My Lock"
+)
 ```
 
 {% endtab %}

--- a/docs/api-clients/devices/update-device.md
+++ b/docs/api-clients/devices/update-device.md
@@ -61,7 +61,7 @@ Name of Property
 {% tab title="Python" %}
 
 ```python
-seam.devices.update(properties={"name": "My Lock"})
+seam.devices.update(device=some_device, name="My Lock")
 ```
 
 {% endtab %}
@@ -69,7 +69,29 @@ seam.devices.update(properties={"name": "My Lock"})
 {% tab title="Javascript" %}
 
 ```typescript
-await seam.devices.unmanaged.update({ properties: { name: "My Lock" } });
+await seam.devices.update({ device_id: "64640ab4-fa90-4818-b455-1336b78c951a", name: "My Lock" });
+```
+
+{% endtab %}
+
+{% tab title="Ruby" %}
+
+```ruby
+seam.devices.update(
+  device_id: "64640ab4-fa90-4818-b455-1336b78c951a", 
+  name: "My Lock"
+)
+```
+
+{% endtab %}
+
+{% tab title="PHP" %}
+
+```php
+$seam->devices->update(
+      device_id: "64640ab4-fa90-4818-b455-1336b78c951a",
+      name: "My Lock"
+    )
 ```
 
 {% endtab %}


### PR DESCRIPTION
A number of issues with our docs for [device update](https://docs.seam.co/latest/api-clients/devices/update-device):

- [x] incorrect example for python (missing device param)
- [x] js example mentions `.unmanaged` and missing device id
- [x] ruby example missing altogether
- [x] php example missing altogether