### PR TITLE
Add Go Code Snippet Tester

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -7,7 +7,6 @@ ARG VARIANT="18"
 # install Go with a multi-stage docker build.
 FROM golang:1.20 AS golang
 
-# Use the "builder" stage to set the PATH variable
 FROM mcr.microsoft.com/vscode/devcontainers/javascript-node:${VARIANT}
 
 RUN apt-get update

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -14,7 +14,18 @@ RUN apt-get install -y ruby ruby-dev
 RUN apt-get install -y default-jdk
 
 # Install Go
-RUN apt-get install -y golang
+ARG GO_VERSION="1.20.10"
+RUN apk add --no-cache ca-certificates
+RUN wget https://golang.org/dl/go${GO_VERSION}.linux-amd64.tar.gz
+RUN tar -C /usr/local -xzf go${GO_VERSION}.linux-amd64.tar.gz
+
+## Set Go environment variables
+ENV PATH="/usr/local/go/bin:${PATH}"
+ENV GOPATH="/go"
+ENV GOBIN="/go/bin"
+
+## Clean up Go installation
+RUN rm go${GO_VERSION}.linux-amd64.tar.gz
 
 RUN gem install seamapi
 RUN pip install seamapi --break-system-packages

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -13,6 +13,9 @@ RUN apt-get install -y ruby ruby-dev
 # Install Java
 RUN apt-get install -y default-jdk
 
+# Install Go
+RUN apt-get install -y golang
+
 RUN gem install seamapi
 RUN pip install seamapi --break-system-packages
 

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,5 +1,13 @@
 ARG VARIANT="18"
 
+# Build stage for Go installation.
+#
+# The latest versions of Go are not available to
+# install with apt-get. Instead, it's simplest to
+# install Go with a multi-stage docker build.
+FROM golang:1.20 AS golang
+
+# Use the "builder" stage to set the PATH variable
 FROM mcr.microsoft.com/vscode/devcontainers/javascript-node:${VARIANT}
 
 RUN apt-get update
@@ -13,19 +21,9 @@ RUN apt-get install -y ruby ruby-dev
 # Install Java
 RUN apt-get install -y default-jdk
 
-# Install Go
-ARG GO_VERSION="1.20.10"
-RUN apk add --no-cache ca-certificates
-RUN wget https://golang.org/dl/go${GO_VERSION}.linux-amd64.tar.gz
-RUN tar -C /usr/local -xzf go${GO_VERSION}.linux-amd64.tar.gz
-
-## Set Go environment variables
+# Copy Go from the golang stage.
+COPY --from=golang /usr/local/go /usr/local/go
 ENV PATH="/usr/local/go/bin:${PATH}"
-ENV GOPATH="/go"
-ENV GOBIN="/go/bin"
-
-## Clean up Go installation
-RUN rm go${GO_VERSION}.linux-amd64.tar.gz
 
 RUN gem install seamapi
 RUN pip install seamapi --break-system-packages

--- a/snippet-playground/go/README.md
+++ b/snippet-playground/go/README.md
@@ -1,0 +1,3 @@
+# Running Go
+
+Just run `go run main.go`

--- a/snippet-playground/go/go.mod
+++ b/snippet-playground/go/go.mod
@@ -1,0 +1,5 @@
+module github.com/seamapi/api-docs/snippet-playground/go
+
+go 1.13
+
+require github.com/seamapi/go v0.1.1

--- a/snippet-playground/go/go.mod
+++ b/snippet-playground/go/go.mod
@@ -2,4 +2,4 @@ module github.com/seamapi/api-docs/snippet-playground/go
 
 go 1.13
 
-require github.com/seamapi/go v0.1.1
+require github.com/seamapi/go v0.1.2

--- a/snippet-playground/go/go.sum
+++ b/snippet-playground/go/go.sum
@@ -2,8 +2,8 @@ github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/seamapi/go v0.1.1 h1:bQ0/Z6RWwHiWATbpIRFbt0uKSTqE8pSQSA3qqsZzZ7A=
-github.com/seamapi/go v0.1.1/go.mod h1:8CROpjACTmlQW4sZAruZ2Xpqi7L5eczyWL7A4sL9Tns=
+github.com/seamapi/go v0.1.2 h1:UbgGeioep6nqUNA0ImvHq3GUdVa98N94ocBy3Ve2nAc=
+github.com/seamapi/go v0.1.2/go.mod h1:8CROpjACTmlQW4sZAruZ2Xpqi7L5eczyWL7A4sL9Tns=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=

--- a/snippet-playground/go/go.sum
+++ b/snippet-playground/go/go.sum
@@ -1,0 +1,13 @@
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/seamapi/go v0.1.1 h1:bQ0/Z6RWwHiWATbpIRFbt0uKSTqE8pSQSA3qqsZzZ7A=
+github.com/seamapi/go v0.1.1/go.mod h1:8CROpjACTmlQW4sZAruZ2Xpqi7L5eczyWL7A4sL9Tns=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
+github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/snippet-playground/go/main.go
+++ b/snippet-playground/go/main.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"math/rand"
+	"os"
+
+	goclient "github.com/seamapi/go/client"
+)
+
+func main() {
+	if err := run(); err != nil {
+		_, _ = fmt.Fprintln(os.Stderr, err.Error())
+		os.Exit(1)
+	}
+}
+
+func run() error {
+	client := goclient.NewClient(
+		goclient.WithBaseURL(fmt.Sprintf("https://%d.fakeseamconnect.seam.vc", rand.Intn(1000000))),
+		goclient.WithAuthApiKey("seam_apikey1_token"),
+	)
+	devices, err := client.Devices.List(context.Background(), nil)
+	if err != nil {
+		return err
+	}
+	return prettyPrint(devices)
+}
+
+func prettyPrint(value interface{}) error {
+	jsonBytes, err := json.MarshalIndent(value, "", "  ")
+	if err != nil {
+		return err
+	}
+	fmt.Println(string(jsonBytes))
+	return nil
+}

--- a/snippet-playground/go/main.go
+++ b/snippet-playground/go/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"math/rand"
 	"os"
@@ -20,20 +19,12 @@ func main() {
 func run() error {
 	client := goclient.NewClient(
 		goclient.WithBaseURL(fmt.Sprintf("https://%d.fakeseamconnect.seam.vc", rand.Intn(1000000))),
-		goclient.WithAuthApiKey("seam_apikey1_token"),
+		goclient.WithApiKey("seam_apikey1_token"),
 	)
 	devices, err := client.Devices.List(context.Background(), nil)
 	if err != nil {
 		return err
 	}
-	return prettyPrint(devices)
-}
-
-func prettyPrint(value interface{}) error {
-	jsonBytes, err := json.MarshalIndent(value, "", "  ")
-	if err != nil {
-		return err
-	}
-	fmt.Println(string(jsonBytes))
+	fmt.Println(devices)
 	return nil
 }

--- a/snippet-playground/go/main.go
+++ b/snippet-playground/go/main.go
@@ -6,7 +6,7 @@ import (
 	"math/rand"
 	"os"
 
-	goclient "github.com/seamapi/go/client"
+	seam "github.com/seamapi/go/client"
 )
 
 func main() {
@@ -17,9 +17,9 @@ func main() {
 }
 
 func run() error {
-	client := goclient.NewClient(
-		goclient.WithBaseURL(fmt.Sprintf("https://%d.fakeseamconnect.seam.vc", rand.Intn(1000000))),
-		goclient.WithApiKey("seam_apikey1_token"),
+	client := seam.NewClient(
+		seam.WithBaseURL(fmt.Sprintf("https://%d.fakeseamconnect.seam.vc", rand.Intn(1000000))),
+		seam.WithApiKey("seam_apikey1_token"),
 	)
 	devices, err := client.Devices.List(context.Background(), nil)
 	if err != nil {


### PR DESCRIPTION
Things changed in this PR:

* The devcontainer is now updated to install `go`.
    * Note that this uses multi-staged docker builds because the latest Go version available on `apt-get` is `1.10`, which is far too old.
* There is now a `go` folder in the snippet-playground.
* Running `go run main.go` will run the Go code snippet against fake seam.