### PR TITLE
upgrade java sdk to `0.1.22`

### DIFF
--- a/snippet-playground/java/build.gradle
+++ b/snippet-playground/java/build.gradle
@@ -7,7 +7,7 @@ repositories {
 }
 
 dependencies {
-    implementation 'io.github.seamapi:java:0.1.15'
+    implementation 'io.github.seamapi:java:0.1.21'
 }
 
 java {

--- a/snippet-playground/java/build.gradle
+++ b/snippet-playground/java/build.gradle
@@ -7,7 +7,7 @@ repositories {
 }
 
 dependencies {
-    implementation 'io.github.seamapi:java:0.1.21'
+    implementation 'io.github.seamapi:java:0.1.22'
 }
 
 java {


### PR DESCRIPTION
This PR upgrades the Java SDK for multiple fixes: 
- print out all properties that are returned in the response
- send `heat_cool` instead of `heatcool`
- `is_managed` properties are treated as boolean (previously a subset were typed as strings)