### PR TITLE
Update java sdk to `0.1.26`

### DIFF
--- a/snippet-playground/java/build.gradle
+++ b/snippet-playground/java/build.gradle
@@ -7,7 +7,7 @@ repositories {
 }
 
 dependencies {
-    implementation 'io.github.seamapi:java:0.1.22'
+    implementation 'io.github.seamapi:java:0.1.26'
 }
 
 java {


### PR DESCRIPTION
This version of the Java SDK has a more simplified experience when connecting a `ConnectWebviewCreateRequest`: 

```java
Map<String, ConnectWebviewsCreateRequestCustomMetadataValue> customMetadata = 
    Map.of("id", CustomMetadataValue.of("user1"));
ConnectWebview createdConnectWebview = seam.connectWebviews().create(ConnectWebviewsCreateRequest.builder()
   .providerCategory(ProviderCategory.STABLE)
   .customMetadata(customMetadata)
   .build());
```

The SDK now also supports `automaticallyManageNewDevices` and `waitForDeviceCreation` 

```java
ConnectWebview createdConnectWebview = seam.connectWebviews().create(ConnectWebviewsCreateRequest.builder()
   .providerCategory(ProviderCategory.STABLE)
   .customMetadata(customMetadata)
   .automaticallyManageNewDevices(true) // <------------- new field
   .build());
```