### PR TITLE
Fix Incorrect Sandbox Token Instruction

### DIFF
--- a/docs/device-guides/sandbox-and-sample-data/assa-abloy-visionline-access-management-system-sample-data.md
+++ b/docs/device-guides/sandbox-and-sample-data/assa-abloy-visionline-access-management-system-sample-data.md
@@ -10,4 +10,7 @@ To use the virtual Visionline Access Control System (ACS) with the virtual [Seam
 3. Connect the virtual Visionline ACS using a Connect Webview and the Visionline sample credentials.&#x20;
 {% endhint %}
 
-<table><thead><tr><th width="192">Username</th><th width="197">Password</th><th>Local IP Address of the Visionline Server</th></tr></thead><tbody><tr><td>jane</td><td>1234</td><td>192.168.1.100</td></tr></tbody></table>
+
+| Username  | Password | Lock Service Code | Local IP Address of the Visionline Server  |
+| --------- | -------- | ----------------- | ------------------------------------------ |
+| jane      | 1234     | 1234              | 192.168.1.100                              |

--- a/docs/device-guides/sandbox-and-sample-data/seam-bridge-sample-data.md
+++ b/docs/device-guides/sandbox-and-sample-data/seam-bridge-sample-data.md
@@ -2,6 +2,6 @@
 
 Use the following set of credentials to add the [Seam Bridge](../../products/seam-bridge-in-development.md) to your Seam [sandbox workspace](../../core-concepts/workspaces/#sandbox-workspaces):
 
-| PIN Code | Bridge Name |
-| -------- | ----------- |
-| 1234     | My Network  |
+| PIN Code   | Bridge Name |
+| ---------- | ----------- |
+| 123456     | My Network  |


### PR DESCRIPTION
Sample sandbox data said token was 1234; that didn't work in the actual sandbox but 123456 did.