### PR TITLE
Iframes must specify the 'allow' attribute to enable copying to clipboard

### DIFF
--- a/docs/api-clients/connect-webviews/embedding-a-connect-webview.md
+++ b/docs/api-clients/connect-webviews/embedding-a-connect-webview.md
@@ -14,6 +14,7 @@ You can use the HTML Iframe to display a connect webview url.
 ```html
 <iframe
   style="border: none;min-height: 600px;height: 100%;width: 100%"
+  allow="clipboard-write"
   src="<your connect_webview.url>"
 />
 ```

--- a/docs/core-concepts/connect-webviews/embedding-a-connect-webview-in-your-app.md
+++ b/docs/core-concepts/connect-webviews/embedding-a-connect-webview-in-your-app.md
@@ -706,6 +706,7 @@ For example:
 
 ```html
 <iframe style="border: none;min-height: 600px;height: 100%;width: 100%"
+allow="clipboard-write"
 src="<your connect_webview.url>"
 />
 ```


### PR DESCRIPTION
This came up in a customer issue: https://seam.unthread.io/dashboard/inbox/all/conversations/8fb52e2b-e124-445f-933c-5b058b0860af